### PR TITLE
add env variable via start script

### DIFF
--- a/start
+++ b/start
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
+
+exec "$@"

--- a/start
+++ b/start
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
+export QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
 
-# required by binder to be the last line
+# must be the last line
 exec "$@"

--- a/start
+++ b/start
@@ -2,4 +2,5 @@
 
 QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
 
+# required by binder to be the last line
 exec "$@"

--- a/start
+++ b/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org


### PR DESCRIPTION
this PR adds an env variable whose value will be appended to the header when making requests to hardware.

the env is added via a `start` script as suggested in [binder documentation](https://mybinder.readthedocs.io/en/latest/using/config_files.html#start-run-code-before-the-user-sessions-starts).

you can verify the env variable got added by checking out the [binder for this PR branch](https://mybinder.org/v2/gh/Qiskit/platypus-binder/va-start-script)

<img width="745" alt="image" src="https://user-images.githubusercontent.com/13156555/180033529-d71c3a2a-fbb5-491f-9368-264e07f0a664.png">

Related
- https://github.com/Qiskit/platypus/issues/1344
- https://github.com/Qiskit/platypus/pull/1360