### PR TITLE
update qiskit requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,12 +14,7 @@ dependencies:
 - numexpr
 - pip:
   - pandas
-  - qiskit==0.37
-  - qiskit==0.37
-  - qiskit-nature==0.4.1
-  - qiskit-machine-learning==0.4.0
-  - qiskit-finance==0.3.2
-  - qiskit-ignis==0.7.0
+  - qiskit[all]~=0.37.0
   - ./qiskit-textbook-src
   - 'qiskit-machine-learning[sparse]'
   - ibm_quantum_widgets


### PR DESCRIPTION
## Changes

update  the qiskit packages included in the binder environment

Fixes https://github.com/Qiskit/platypus-binder/issues/18

## Implementation details

`environment.yml` was updated to install `qiskit[all]` instead of specifying individual packages

## How to read this PR

go to this [PR's branch binder env](https://mybinder.org/v2/gh/Qiskit/platypus-binder/va-qiskit-reqs) and run qiskit code (e.g., the visualization code in https://github.com/Qiskit/platypus-binder/issues/18)

## Screenshots

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/181359708-59a5346e-598e-458a-b973-67b0f9f56a59.png">
