### PR TITLE
Update start

### DIFF
--- a/start
+++ b/start
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+# custom header for requests
 export QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
+
+# grader config
+export QC_GRADE_ONLY=true
 
 # must be the last line
 exec "$@"


### PR DESCRIPTION
## Changes

configure grader

## Implementation details

by default the grader attempts to submit to the challenges API. this functionality is not needed for learning platform autograding. 

this PR updates adds environment variable to only grade (and bypass challenge API submission)

## How to read this PR

point your local environment to the PR branch's binder environment: https://mybinder.org/v2/gh/qiskit/platypus-binder/va-grader-update

you should be able to successfully run the example grading exercise

## Screenshots

**before**

<img width="978" alt="image" src="https://user-images.githubusercontent.com/13156555/183144182-dbae0267-ee4a-4606-a93e-82fe5f0c9339.png">

**after**

<img width="977" alt="image" src="https://user-images.githubusercontent.com/13156555/183145351-52955689-a7b9-450b-9ca1-2c17ba24065f.png">

