### PR TITLE
Add environment variable to disable tensorflow information messages

### DIFF
--- a/start
+++ b/start
@@ -6,5 +6,8 @@ export QE_CUSTOM_CLIENT_APP_HEADER=learn.qiskit.org
 # grader config
 export QC_GRADE_ONLY=true
 
+# ignore tensorflow info messages
+export TF_CPP_MIN_LOG_LEVEL=1
+
 # must be the last line
 exec "$@"


### PR DESCRIPTION
Tensorflow currently gives information messages which are unnecessary and potentially confusing to the user. This environment variable silences these, but will still allow warnings / errors to be reported.

For an example, try the code on [the QGAN page](https://learn.qiskit.org/course/machine-learning/quantum-generative-adversarial-networks):

![Screenshot 2022-09-01 at 16 25 44](https://user-images.githubusercontent.com/36071638/187952423-4d0e4ea5-a31f-4e61-a131-2b687096cd84.png)
