### PR TITLE
Bump tensorflow

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - ./qiskit-textbook-src
   - 'qiskit-machine-learning[sparse]'
   - ibm_quantum_widgets
-  - tensorflow==2.9.1
+  - tensorflow==2.9.3
   - pyscf==2.0.1
   - git+https://github.com/qiskit-community/Quantum-Challenge-Grader.git@main
   - git+https://github.com/anedumla/quantum_linear_solvers


### PR DESCRIPTION
Bumps tensorflow to `2.9.3` after it was upgraded in Platypus (see https://github.com/Qiskit/platypus/pull/1707).
