### PR TITLE
Downgrade ipywidgets

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pip:
   - pandas
   - torchvision
+  - ipywidgets==7
   - qiskit[all]~=0.39.0
   - qiskit-ibm-runtime~=0.7.0
   - ./qiskit-textbook-src


### PR DESCRIPTION
It seems `ipywidgets>=8` does not work on the website.

See https://github.com/Qiskit/platypus/issues/1690 for bug & discussion.