### PR TITLE
Update requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,8 +16,14 @@ dependencies:
   - pandas
   - torchvision
   - ipywidgets>=7.3.0,<8.0
-  - qiskit[all]~=0.39.0
-  - qiskit-ibm-runtime~=0.8.0
+  - qiskit==0.41.1
+  - qiskit-ibm-runtime~=0.9.1
+  - qiskit-nature==0.4.1
+  - qiskit-machine-learning==0.4.0
+  - qiskit-finance==0.3.2
+  - qiskit-machine-learning[sparse]
+  - qiskit-experiments==0.4.0
+  - tweedledum==1.1.1
   - ./qiskit-textbook-src
   - 'qiskit-machine-learning[sparse]'
   - ibm_quantum_widgets


### PR DESCRIPTION
## Changes

- Remove `qiskit[all]` dependency to give us control over each specific package version.
- Upgrade `qiskit` and `qiskit-ibm-runtime`; as of yesterday, the latest versions of these packages do not have dependency conflicts, so we can safely upgrade them.
- Downgrade `qiskit-nature`; the textbook does not currently work with `0.5.x`, which is what was previously installed.

## Screenshots

Here's the environment building correctly on https://mybinder.org.

<img src="https://user-images.githubusercontent.com/36071638/222733375-5db9aa6a-1690-4c24-8095-2f0916568a52.png" height=500>

