### PR TITLE
remove package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - tweedledum==1.1.1
   - ./qiskit-textbook-src
   - 'qiskit-machine-learning[sparse]'
-  - ibm_quantum_widgets
+  # - ibm_quantum_widgets
   - tensorflow==2.9.3
   - pyscf==2.0.1
   - bokeh==3.0.2


### PR DESCRIPTION
## Changes

do not install `ibm_quantum_widgets` to resolve error:

```
ERROR: No matching distribution found for ibm_quantum_widgets
```

## Implementation details

comment out the `ibm_quantum_widgets` package from the `environments.yml`

## How to read this PR

- review the `environments.yml` change
- confirm the environment deploys with no error

---

FYI @frankharkins 

